### PR TITLE
added mapping from grib to cf for precipitation flux

### DIFF
--- a/staticData/metarelate.net/concepts.ttl
+++ b/staticData/metarelate.net/concepts.ttl
@@ -5064,6 +5064,12 @@
 	<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.metarelate.net/vocabulary/index.html#Component> ;
 	.
 
+<http://www.metarelate.net/metOcean/component/82dd21073b4d840aa74488e246fecf745abf9e20>
+	<http://codes.wmo.int/def/grib2/parameterId> <http://codes.wmo.int/grib2/codeflag/4.2/0-1-7> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://codes.wmo.int/def/codeform/GRIB-message> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.metarelate.net/vocabulary/index.html#Component> ;
+	.
+
 <http://www.metarelate.net/metOcean/component/82dec5c57c023a74521df97ba3ebb0c4f3936abf>
 	<http://def.scitools.org.uk/cfdatamodel/standard_name> <http://vocab.nerc.ac.uk/standard_name/product_of_omega_and_air_temperature> ;
 	<http://def.scitools.org.uk/cfdatamodel/units> "unknown" ;

--- a/staticData/metarelate.net/mappings.ttl
+++ b/staticData/metarelate.net/mappings.ttl
@@ -1739,6 +1739,15 @@
 	<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.metarelate.net/vocabulary/index.html#Mapping> ;
 	.
 
+<http://www.metarelate.net/metOcean/mapping/293841678567da161d00265316a1629d0e025c2e>
+	<http://purl.org/dc/terms/creator> <https://github.com/esc24> ;
+	<http://purl.org/dc/terms/date> "2015-01-09T13:21:43.750518" ;
+	<http://www.metarelate.net/vocabulary/index.html#invertible> "True" ;
+	<http://www.metarelate.net/vocabulary/index.html#source> <http://www.metarelate.net/metOcean/component/82dd21073b4d840aa74488e246fecf745abf9e20> ;
+	<http://www.metarelate.net/vocabulary/index.html#target> <http://www.metarelate.net/metOcean/component/5613c526cd3db584e585fa576a6ef6d3582de23c> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.metarelate.net/vocabulary/index.html#Mapping> ;
+	.
+
 <http://www.metarelate.net/metOcean/mapping/2959a1da2656099ef3d4083dbe5fcaa5a6148b86>
 	<http://purl.org/dc/terms/creator> <https://github.com/NSavage> ;
 	<http://purl.org/dc/terms/date> "2014-11-06T13:24:53.204810" ;


### PR DESCRIPTION
Adds mapping from grib discipline 0, category 1, number 7 to `precipitation_flux` in `kg m-2 s-1`

mapping file contents:

```
Disc|pCat|pNum|CFName|units
0|1|7|precipitation_flux|kg m-2 s-1
```